### PR TITLE
Use `this` to refer to global object.

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -39,7 +39,8 @@ module.exports = {
   ],
   output: {
     path: path.resolve(__dirname, "dist"),
-    filename: "bundle.js"
+    filename: "bundle.js",
+    globalObject: "this"
   },
   devServer: {
     contentBase: "./assets",


### PR DESCRIPTION
This fixes a "window is not defined" error that prevented hot module
replacement from loading correctly for me. See also
https://github.com/webpack/webpack/issues/6642#issuecomment-370222543

---------

This gets the client to load for me, though it's still not quite working properly. (I'll post a separate issue in a moment.) So I recommend you try running it yourself before merging this, just to make sure it didn't inadvertently break something.